### PR TITLE
ci(github-actions): run tests only on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
   workflow_dispatch:


### PR DESCRIPTION
Remove push trigger from test workflow to avoid redundant test runs since all changes to main require PRs. Tests still run on every PR and can be triggered manually via workflow_dispatch.