### PR TITLE
fix(schema): resolve LLMProvider $ref by moving nested $defs to root level

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -612,19 +612,6 @@
             "then": {
               "properties": {
                 "inputs": {
-                  "$defs": {
-                    "LLMProvider": {
-                      "description": "Enum for supported LLM providers.",
-                      "enum": [
-                        "openai",
-                        "anthropic",
-                        "gemini",
-                        "ollama"
-                      ],
-                      "title": "LLMProvider",
-                      "type": "string"
-                    }
-                  },
                   "additionalProperties": false,
                   "description": "Inputs for LLMCall block",
                   "properties": {
@@ -1357,20 +1344,18 @@
       "title": "HttpCallInput",
       "type": "object"
     },
+    "LLMProvider": {
+      "description": "Enum for supported LLM providers.",
+      "enum": [
+        "openai",
+        "anthropic",
+        "gemini",
+        "ollama"
+      ],
+      "title": "LLMProvider",
+      "type": "string"
+    },
     "LLMCallInput": {
-      "$defs": {
-        "LLMProvider": {
-          "description": "Enum for supported LLM providers.",
-          "enum": [
-            "openai",
-            "anthropic",
-            "gemini",
-            "ollama"
-          ],
-          "title": "LLMProvider",
-          "type": "string"
-        }
-      },
       "additionalProperties": false,
       "description": "Input model for LLMCall executor.\n\nAll inputs are pre-resolved by VariableResolver:\n- {{secrets.OPENAI_API_KEY}} \u2192 actual key value\n- {{inputs.prompt}} \u2192 actual prompt text\n- {{blocks.previous.outputs.data}} \u2192 actual data",
       "properties": {


### PR DESCRIPTION
The schema generator was creating nested $defs within executor input schemas,
causing $ref resolution failures for types like LLMProvider. This fix extracts
and merges all nested $defs to the root level during schema generation, using
the same pattern already applied to WorkflowOutputSchema.

This ensures that $ref paths like #/$defs/LLMProvider correctly resolve to
types defined at the root level, fixing the "$ref '/$defs/LLMProvider' can
not be resolved" error introduced in PR #20.

- Extracts nested $defs from executor input schemas
- Merges them to root-level $defs before inlining
- Maintains consistency with WorkflowOutputSchema pattern