### PR TITLE
refactor(engine): move scratch directory to OS temp with workflow-scoped lifecycle

### DIFF
--- a/src/workflows_mcp/engine/execution.py
+++ b/src/workflows_mcp/engine/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -37,6 +38,11 @@ class ExecutionInternal(BaseModel):
     workflow_stack: list[str] = Field(
         default_factory=list,
         description="Stack of workflow names for recursion tracking",
+    )
+
+    scratch_dir: Path | None = Field(
+        default=None,
+        description="Workflow-scoped scratch directory (absolute path in system temp)",
     )
 
 
@@ -137,6 +143,15 @@ class Execution(BaseModel):
     def get_parent_workflow(self) -> str | None:
         """Get parent workflow name (for composition)."""
         return self._internal.workflow_stack[-1] if self._internal.workflow_stack else None
+
+    @property
+    def scratch_dir(self) -> Path | None:
+        """Get workflow-scoped scratch directory."""
+        return self._internal.scratch_dir
+
+    def set_scratch_dir(self, scratch_dir: Path) -> None:
+        """Set workflow-scoped scratch directory."""
+        self._internal.scratch_dir = scratch_dir
 
     @model_validator(mode="before")
     @classmethod

--- a/src/workflows_mcp/engine/executor_base.py
+++ b/src/workflows_mcp/engine/executor_base.py
@@ -268,6 +268,12 @@ class ExecutorRegistry(BaseModel):
             # Get the actual Pydantic schema from the executor
             input_schema = executor.get_input_schema()
 
+            # Extract and merge nested $defs to root level (same as WorkflowOutputSchema)
+            # This ensures types like LLMProvider are accessible at root for $ref
+            # $ref uses absolute paths (#/$defs/Type), so nested $defs won't resolve
+            nested_defs = input_schema.pop("$defs", {})
+            definitions.update(nested_defs)
+
             # Store in definitions
             definitions[f"{type_name}Input"] = input_schema
             block_types.append(type_name)

--- a/src/workflows_mcp/tools.py
+++ b/src/workflows_mcp/tools.py
@@ -145,6 +145,7 @@ async def execute_workflow(
         workflow=workflow_schema,
         runtime_inputs=inputs,
         context=exec_context,
+        debug=debug,
     )
 
     # Format response using ExecutionResult.to_response()
@@ -266,6 +267,7 @@ async def execute_inline_workflow(
         workflow=workflow_schema,
         runtime_inputs=inputs,
         context=exec_context,
+        debug=debug,
     )
 
     # Format response using ExecutionResult.to_response()


### PR DESCRIPTION
Replace project-relative `.scratch/` directories with workflow-scoped temp directories
to prevent project pollution and enable concurrent workflow execution.

Changes:
- Create scratch in system temp: `tempfile.gettempdir()/workflows-{name}-{uuid8}`
- Add scratch_dir field to ExecutionInternal with accessor methods
- Implement automatic cleanup in workflow_runner finally block (respects debug mode)
- Update Shell executor to use workflow scratch from execution context
- Remove .scratch creation and .gitignore management from Shell executor
- Pass debug flag through MCP tools to preserve scratch when needed
- Treat $SCRATCH paths as unsafe=True to allow absolute paths in validation

Benefits:
- No .scratch/ pollution in working directories
- Proper temp directory cleanup (OS-managed)
- Concurrent workflow isolation (unique IDs)
- Debug mode preserves scratch for analysis