### PR TITLE
feat(for_each): add dynamic key interpolation and fractal execution s…

### DIFF
--- a/src/src/main.py
+++ b/src/src/main.py
@@ -1,1 +1,0 @@
-print('hello world')

--- a/src/src/utils.py
+++ b/src/src/utils.py
@@ -1,1 +1,0 @@
-# Utility functions

--- a/src/workflows_mcp/engine/block.py
+++ b/src/workflows_mcp/engine/block.py
@@ -40,6 +40,7 @@ class BlockOutput(BaseModel):
     meta: dict[str, Any] = Field(
         default_factory=dict,
         description="Executor-specific metadata fields (exit_code, tokens_used, etc.)",
+        exclude=True,
     )
 
     model_config = {"extra": "allow"}

--- a/src/workflows_mcp/engine/orchestrator.py
+++ b/src/workflows_mcp/engine/orchestrator.py
@@ -36,7 +36,11 @@ class BlockExecution(BaseModel):
     Result of executing a single block.
 
     This wraps the executor output with execution metadata.
+    Mirrors Execution structure for fractal consistency.
     """
+
+    # Resolved inputs used for execution (mirrors Execution.inputs)
+    inputs: dict[str, Any] = {}
 
     # Executor output (or None if paused/failed)
     output: BaseModel | None
@@ -176,6 +180,7 @@ class BlockOrchestrator:
                 )
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=output,
                 metadata=metadata,
                 paused=False,
@@ -198,6 +203,7 @@ class BlockOrchestrator:
             )
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=None,
                 metadata=metadata,
                 paused=True,
@@ -237,6 +243,7 @@ class BlockOrchestrator:
             output = executor.output_type()
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=output,
                 metadata=metadata,
                 paused=False,
@@ -300,6 +307,7 @@ class BlockOrchestrator:
             )
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=output,
                 metadata=metadata,
                 paused=False,
@@ -322,6 +330,7 @@ class BlockOrchestrator:
             )
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=None,
                 metadata=metadata,
                 paused=True,
@@ -348,6 +357,7 @@ class BlockOrchestrator:
             )
 
             return BlockExecution(
+                inputs=inputs.model_dump(),
                 output=None,
                 metadata=metadata,
                 paused=False,

--- a/tests/snapshots/for-each-dict-demo.json
+++ b/tests/snapshots/for-each-dict-demo.json
@@ -1,6 +1,7 @@
 {
   "outputs": {
     "all_successful": true,
+    "api_exit_code": 0,
     "execution_mode": "sequential",
     "services_configured": 3
   },

--- a/tests/snapshots/for-each-dynamic-key.json
+++ b/tests/snapshots/for-each-dynamic-key.json
@@ -1,0 +1,11 @@
+{
+  "outputs": {
+    "all_succeeded": true,
+    "api_exit_code": 0,
+    "dynamic_matches_static": true,
+    "secondary_exit_code": 0,
+    "target_exit_code": 0,
+    "total_services": 3
+  },
+  "status": "success"
+}

--- a/tests/snapshots/for-each-list-demo.json
+++ b/tests/snapshots/for-each-list-demo.json
@@ -2,6 +2,7 @@
   "outputs": {
     "all_succeeded": true,
     "failed_count": 0,
+    "first_file_exit_code": 0,
     "total_files": 3
   },
   "status": "success"

--- a/tests/workflows/for-each-dict-demo.yaml
+++ b/tests/workflows/for-each-dict-demo.yaml
@@ -81,3 +81,8 @@ outputs:
     value: "{{blocks.configure_services.metadata.mode}}"
     type: str
     description: Execution mode used (sequential)
+
+  api_exit_code:
+    value: "{{blocks.configure_services['api'].outputs.exit_code}}"
+    type: num
+    description: Exit code from API service configuration

--- a/tests/workflows/for-each-dynamic-key.yaml
+++ b/tests/workflows/for-each-dynamic-key.yaml
@@ -1,0 +1,104 @@
+name: for-each-dynamic-key
+description: |
+  Test dynamic key interpolation in bracket notation (ADR-009).
+
+  Validates that bracket notation supports variable interpolation:
+  blocks.id[{{inputs.key}}].outputs.field
+
+  This enables dynamic access to for_each iteration results.
+
+tags:
+  - test
+  - for_each
+  - dynamic
+  - interpolation
+
+inputs:
+  services:
+    type: dict
+    default:
+      api:
+        port: 8000
+        status: "running"
+      worker:
+        port: 8001
+        status: "idle"
+      admin:
+        port: 8002
+        status: "stopped"
+    description: Dictionary of services
+
+  target_service:
+    type: str
+    default: "api"
+    description: Service name to access dynamically
+
+  secondary_service:
+    type: str
+    default: "worker"
+    description: Second service for validation
+
+blocks:
+  # For_each block that processes all services
+  - id: check_services
+    type: Shell
+    for_each: "{{inputs.services}}"
+    for_each_mode: parallel
+    inputs:
+      command: |
+        echo "Checking service: {{each.key}}"
+        echo "Port: {{each.value.port}}"
+        echo "Status: {{each.value.status}}"
+        echo "Service {{each.key}} on port {{each.value.port}}: {{each.value.status}}"
+
+  # Use dynamic key to access specific service result
+  - id: verify_target
+    type: Shell
+    depends_on: [check_services]
+    inputs:
+      command: |
+        echo "=== Dynamic Key Access Test ==="
+        echo ""
+        echo "Target service: {{inputs.target_service}}"
+        echo "Target exit code: {{blocks.check_services[{{inputs.target_service}}].outputs.exit_code}}"
+        echo "Target succeeded: {{blocks.check_services[{{inputs.target_service}}].metadata.succeeded}}"
+        echo ""
+        echo "Secondary service: {{inputs.secondary_service}}"
+        echo "Secondary exit code: {{blocks.check_services[{{inputs.secondary_service}}].outputs.exit_code}}"
+        echo ""
+        echo "Dynamic access validated!"
+
+outputs:
+  # Static bracket access (baseline)
+  api_exit_code:
+    value: "{{blocks.check_services['api'].outputs.exit_code}}"
+    type: num
+    description: API service exit code (static key)
+
+  # Dynamic bracket access via interpolation
+  target_exit_code:
+    value: "{{blocks.check_services[{{inputs.target_service}}].outputs.exit_code}}"
+    type: num
+    description: Target service exit code (dynamic key)
+
+  secondary_exit_code:
+    value: "{{blocks.check_services[{{inputs.secondary_service}}].outputs.exit_code}}"
+    type: num
+    description: Secondary service exit code (dynamic key)
+
+  # Verify dynamic access matches static access
+  dynamic_matches_static:
+    value: "{{blocks.check_services[{{inputs.target_service}}].outputs.exit_code}} == {{blocks.check_services['api'].outputs.exit_code}}"
+    type: bool
+    description: Validates dynamic key resolves to same value as static
+
+  # Parent metadata access (should work regardless)
+  total_services:
+    value: "{{blocks.check_services.metadata.count}}"
+    type: num
+    description: Total services checked
+
+  all_succeeded:
+    value: "{{blocks.check_services.metadata.succeeded}}"
+    type: bool
+    description: All services succeeded

--- a/tests/workflows/for-each-list-demo.yaml
+++ b/tests/workflows/for-each-list-demo.yaml
@@ -70,3 +70,8 @@ outputs:
     value: "{{blocks.analyze_files.metadata.succeeded}}"
     type: bool
     description: Whether all files were processed successfully
+
+  first_file_exit_code:
+    value: "{{blocks.analyze_files['0'].outputs.exit_code}}"
+    type: num
+    description: Exit code from processing first file


### PR DESCRIPTION
add dynamic key interpolation and fractal execution support

Implement bracket notation with nested variable interpolation for dynamic access to for_each iteration results. Add fractal execution pattern for Workflow blocks within iterations.

Key changes:
- Variable resolver now supports `{{blocks.id[{{var}}].field}}` syntax
- For_each blocks auto-inject 'blocks' namespace for proper iteration access
- Fractal execution preserves nested workflow outputs and blocks structure
- BlockExecution now stores resolved inputs for debugging
- Add comprehensive test coverage for dynamic key access patterns

Breaking changes:
- Bracket notation access pattern changed for for_each blocks
- Requires explicit bracket notation: `blocks.id["key"]` instead of `blocks.id.key`

Cleanup placeholder files (src/src/main.py, src/src/utils.py) from initial project setup.